### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install packages
+        run: sudo gem install mdl
+      - name: Lint markdown files
+        run: mdl *.md


### PR DESCRIPTION
Use GitHub Action to run CI, all CI does is lint markdown files with `mdl` command, see https://github.com/markdownlint/markdownlint project.

Currently, the default rules of `mdl` already found some issues in bunch of files:

```
% mdl * | grep "MD\d\+.*$" -o | sort | uniq
MD001 Header levels should only increment by one level at a time
MD004 Unordered list style
MD009 Trailing spaces
MD012 Multiple consecutive blank lines
MD025 Multiple top level headers in the same document
MD029 Ordered list item prefix
MD030 Spaces after list markers
MD032 Lists should be surrounded by blank lines
MD036 Emphasis used instead of a header
```

Most of the default rules are fine, except:

- [MD004](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md004---unordered-list-style): `:dash` should be preferred, because `-` only needs a single key stroke while `*` requires shift
- [MD029](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md029---ordered-list-item-prefix): it's hard to say which one is better, but `:one` definitely makes life easier.

I suggest we should discuess about the rules, once aligned I can add a config file for `mdl` and fix remaining lint issues in PR.