### PR TITLE
add missing spaces between half and full-width characters

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,0 +1,8 @@
+{
+  "filters": {},
+  "rules": {
+    "ja-space-between-half-and-full-width": {
+      "space": "always"
+    }
+  }
+}


### PR DESCRIPTION
Fixed by **textlint**, see the configuration in `.textlintrc`.