### PR TITLE
docs: 推荐“孕养一日”衍生项目

### DIFF
--- a/.github/templates/readme_template.md
+++ b/.github/templates/readme_template.md
@@ -56,3 +56,4 @@ docker run -d -p 5000:5000 aiursoft/howtocookviewer
 - [HowToCook-py-mcp 让 AI 助手变身私人大厨，为你的一日三餐出谋划策 (Python)](https://github.com/DusKing1/howtocook-py-mcp)
 - [whatToEat 今天吃什么？的决策工具，帮助你快速选择合适的菜谱。](https://github.com/ryanuo/whatToEat)
 - [厨房计划：开源中文菜谱 API - 由社区贡献，人人可用](https://proj.kitchen)
+- [孕养一日：基于权威指南的离线孕期膳食与生活记录应用；从 HowToCook 固定版本筛选家常烹饪思路，按孕期食品安全要求改写并保留来源追溯，提供覆盖孕 0 周 0 天至 41 周 6 天的 294 个不同日五餐菜单、完整离线菜谱、安全分流，以及餐食、体重、活动和补充剂的本地记录；无账号、无后端、无遥测，并支持导出 JSON 与就诊沟通摘要 PDF。](https://github.com/lichong-a/pregnancy-nutrition-tracking)

--- a/.github/templates/readme_template.md
+++ b/.github/templates/readme_template.md
@@ -56,4 +56,4 @@ docker run -d -p 5000:5000 aiursoft/howtocookviewer
 - [HowToCook-py-mcp 让 AI 助手变身私人大厨，为你的一日三餐出谋划策 (Python)](https://github.com/DusKing1/howtocook-py-mcp)
 - [whatToEat 今天吃什么？的决策工具，帮助你快速选择合适的菜谱。](https://github.com/ryanuo/whatToEat)
 - [厨房计划：开源中文菜谱 API - 由社区贡献，人人可用](https://proj.kitchen)
-- [孕养一日：基于权威指南的离线孕期膳食与生活记录应用；从 HowToCook 固定版本筛选家常烹饪思路，按孕期食品安全要求改写并保留来源追溯，提供覆盖孕 0 周 0 天至 41 周 6 天的 294 个不同日五餐菜单、完整离线菜谱、安全分流，以及餐食、体重、活动和补充剂的本地记录；无账号、无后端、无遥测，并支持导出 JSON 与就诊沟通摘要 PDF。](https://github.com/lichong-a/pregnancy-nutrition-tracking)
+- [孕养一日：离线孕期膳食与生活记录APP](https://github.com/lichong-a/pregnancy-nutrition-tracking)

--- a/README.md
+++ b/README.md
@@ -468,3 +468,4 @@ docker run -d -p 5000:5000 aiursoft/howtocookviewer
 - [HowToCook-py-mcp 让 AI 助手变身私人大厨，为你的一日三餐出谋划策 (Python)](https://github.com/DusKing1/howtocook-py-mcp)
 - [whatToEat 今天吃什么？的决策工具，帮助你快速选择合适的菜谱。](https://github.com/ryanuo/whatToEat)
 - [厨房计划：开源中文菜谱 API - 由社区贡献，人人可用](https://proj.kitchen)
+- [孕养一日：基于权威指南的离线孕期膳食与生活记录应用；从 HowToCook 固定版本筛选家常烹饪思路，按孕期食品安全要求改写并保留来源追溯，提供覆盖孕 0 周 0 天至 41 周 6 天的 294 个不同日五餐菜单、完整离线菜谱、安全分流，以及餐食、体重、活动和补充剂的本地记录；无账号、无后端、无遥测，并支持导出 JSON 与就诊沟通摘要 PDF。](https://github.com/lichong-a/pregnancy-nutrition-tracking)

--- a/README.md
+++ b/README.md
@@ -468,4 +468,4 @@ docker run -d -p 5000:5000 aiursoft/howtocookviewer
 - [HowToCook-py-mcp 让 AI 助手变身私人大厨，为你的一日三餐出谋划策 (Python)](https://github.com/DusKing1/howtocook-py-mcp)
 - [whatToEat 今天吃什么？的决策工具，帮助你快速选择合适的菜谱。](https://github.com/ryanuo/whatToEat)
 - [厨房计划：开源中文菜谱 API - 由社区贡献，人人可用](https://proj.kitchen)
-- [孕养一日：基于权威指南的离线孕期膳食与生活记录应用；从 HowToCook 固定版本筛选家常烹饪思路，按孕期食品安全要求改写并保留来源追溯，提供覆盖孕 0 周 0 天至 41 周 6 天的 294 个不同日五餐菜单、完整离线菜谱、安全分流，以及餐食、体重、活动和补充剂的本地记录；无账号、无后端、无遥测，并支持导出 JSON 与就诊沟通摘要 PDF。](https://github.com/lichong-a/pregnancy-nutrition-tracking)
+- [孕养一日：离线孕期膳食与生活记录APP](https://github.com/lichong-a/pregnancy-nutrition-tracking)


### PR DESCRIPTION
## 变更内容

- 在 README 的“衍生作品推荐”末尾新增“孕养一日”项目及项目链接。
- README 可见推荐文字按要求压缩为 20 个字符以内，完整推荐理由保留在本 PR 说明中。
- 同步更新 README 生成模板，避免主分支部署工作流重新生成 README 时覆盖该推荐。

## 推荐理由

“孕养一日”不是与 HowToCook 主题无关的普通应用：项目固定核对 HowToCook 提交 `0477799945082b72d6ac5c86a9752fddccf086e4`，从中筛选 17 条实际存在的家常菜谱路径，参考备料顺序、火候和操作思路；同时排除不适合孕期的生食、未熟食物、高汞鱼类及酒精配料等风险，并对采用的做法补充彻底加热、生熟分开、及时冷藏等食品安全要求。每道改编菜谱还保留上游路径和 Git blob 指纹，使 HowToCook 的来源关系清晰、可追溯。

项目把这些经过筛选的烹饪思路放进更完整的孕期日常场景：为普通风险且处于适用范围的用户提供覆盖孕 `0 周 0 天—41 周 6 天` 的 294 个不同日五餐菜单，并内置 180 道完整菜谱、60 种简单搭配和离线菜品封面；不适用于通用菜单的多胎、高风险、复杂过敏或特殊饮食情况会进入专业评估路径，而不会强行生成普通建议。

它还兼顾证据边界和实际使用体验：餐单规则保留来源、版本、适用人群与安全边界，明确定位为健康教育和生活记录工具，不替代产检、诊断或治疗；应用无账号、无后端、无联网请求、无遥测，餐食、体重、活动和补充剂记录保存在本地，并支持导出结构化 JSON 或就诊沟通摘要 PDF。因此，它既延伸了 HowToCook 的家庭烹饪价值，也为孕期用户提供了更安全、可执行、隐私友好的日常安排方式。

## 影响范围

仅更新文档及其生成模板，不修改菜谱、程序逻辑或运行时行为。

## 验证

- 可见推荐文字为“孕养一日：离线孕期膳食与生活记录APP”，共 19 个字符。
- `npm run lint`：通过（textlint、markdownlint、manual lint）。
- `git diff --check`：通过。
- 已确认 README 与生成模板中的推荐完全一致。

## 注意

- [x] 请确保此 Pull Request 能够通过自动化代码检查。

## 签署

- [x] 我确保了我的内容不涉及版权内容，并且授权它 The Unlicense 协议。
